### PR TITLE
Implement PDF generation and chat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Pruebas manuales
+
+Para comprobar la generación y descarga de PDF desde `PreviewPane`:
+
+1. Inicia el servidor con `npm run dev` y abre la aplicación en `http://localhost:3000`.
+2. Selecciona un informe en la barra lateral y haz clic en **Ver Informe Completo**.
+3. Dentro del diálogo pulsa **Descargar PDF**. Se debería iniciar la descarga tras unos segundos.
+4. Abre el archivo descargado y verifica que el contenido coincide con la vista previa.

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,18 +1,51 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
+/**
+ * Endpoint que conecta con un modelo de IA externo (OpenAI) para obtener una
+ * respuesta basada en el mensaje recibido.
+ */
 export async function POST(request: Request) {
   try {
     const { message } = await request.json();
 
-    // TODO: Implementar lógica real de IA o procesamiento
-    const reply = `Respuesta dummy para: "${message}". Aquí irá la lógica de IA o atención manual.`;
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "Falta la clave OPENAI_API_KEY" },
+        { status: 500 },
+      );
+    }
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: message }],
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error("Error al llamar a OpenAI:", text);
+      return NextResponse.json(
+        { error: "Error al obtener respuesta de IA" },
+        { status: 500 },
+      );
+    }
+
+    const data = await response.json();
+    const reply = data.choices?.[0]?.message?.content || "";
 
     return NextResponse.json({ reply });
   } catch (error) {
-    console.error('Error en /api/chat:', error);
+    console.error("Error en /api/chat:", error);
     return NextResponse.json(
-      { error: 'Error al procesar la solicitud' },
-      { status: 500 }
+      { error: "Error al procesar la solicitud" },
+      { status: 500 },
     );
   }
-} 
+}

--- a/src/lib/puppeteer.ts
+++ b/src/lib/puppeteer.ts
@@ -1,11 +1,27 @@
 /**
- * Stub para la generación de PDFs usando Puppeteer
- * TODO: Implementar la generación real de PDFs
+ * Genera un PDF a partir de una cadena HTML utilizando Puppeteer.
+ *
+ * Se realiza una importación dinámica de la librería para evitar que
+ * Next.js intente resolverla en tiempo de compilación cuando la dependencia
+ * no esté instalada. Se asume que el entorno de ejecución dispone de
+ * `puppeteer`.
  */
 export async function generatePdf(html: string): Promise<Buffer> {
-  // Simulamos un delay de procesamiento
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  // Por ahora, devolvemos un buffer dummy
-  return Buffer.from('PDF-DUMMY');
-} 
+  const puppeteer = await import("puppeteer");
+
+  let browser: import("puppeteer").Browser | null = null;
+
+  try {
+    browser = await puppeteer.launch({
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    });
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: "networkidle0" });
+    const pdfBuffer = await page.pdf({ format: "A4" });
+    return pdfBuffer;
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement server-side PDF generation using Puppeteer
- connect `/api/chat` route with OpenAI API
- document manual test steps for PDF download

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*