### PR TITLE
Unify PreviewPaneProps

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -30,19 +30,11 @@ import {
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import type { PreviewPaneProps } from "@/types";
 
 // Importar html2pdf solo en el cliente
 let html2pdf: any = null;
 
-interface ReportPreviewItem {
-  id: string;
-  name: string;
-  previewHtml: string;
-}
-
-interface PreviewPaneProps {
-  reports: ReportPreviewItem[];
-}
 
 interface PDFOptions {
   pageSize: 'one_long_page' | 'a0' | 'a1' | 'a2' | 'a3' | 'a4' | 'a5' | 'a6' | 'letter' | 'legal';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,8 +46,12 @@ export interface ChatWindowProps {
   isLoading?: boolean;
 }
 
-export interface PreviewPaneProps {
+export interface ReportPreviewItem {
+  id: string;
+  name: string;
   previewHtml: string;
-  onEdit?: (html: string) => void;
-  isEditable?: boolean;
-} 
+}
+
+export interface PreviewPaneProps {
+  reports: ReportPreviewItem[];
+}


### PR DESCRIPTION
## Summary
- refactor `PreviewPane` to import `PreviewPaneProps` from central types
- move `ReportPreviewItem` and `PreviewPaneProps` definitions to `src/types`

## Testing
- `npm run lint` *(fails: `next` not found)*